### PR TITLE
Fix Telegram handle not checking for duplicates

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -186,6 +186,10 @@ If a student with the same phone number already exists:
 <code>This phone number is already used by another student.</code>
 </div>
 
+If a student with the same Telegram handle already exists:
+<div style="border: 1px solid #d9d9d9; border-radius: 6px; padding: 8px 12px; margin: 8px 0;">
+<code>This Telegram handle is already used by another student.</code>
+</div>
 </div>
 ### Listing all students : `list`
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -41,7 +41,8 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "This ID already exists in the address book.";
     public static final String MESSAGE_DUPLICATE_EMAIL = "This email is already used by another student.";
     public static final String MESSAGE_DUPLICATE_PHONE = "This phone number is already used by another student.";
-    public static final String MESSAGE_DUPLICATE_TELE_HANDLE = "This Telegram handle is already used by another student.";
+    public static final String MESSAGE_DUPLICATE_TELE_HANDLE =
+            "This Telegram handle is already used by another student.";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -41,6 +41,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "This ID already exists in the address book.";
     public static final String MESSAGE_DUPLICATE_EMAIL = "This email is already used by another student.";
     public static final String MESSAGE_DUPLICATE_PHONE = "This phone number is already used by another student.";
+    public static final String MESSAGE_DUPLICATE_TELE_HANDLE = "This Telegram handle is already used by another student.";
 
     private final Person toAdd;
 
@@ -65,6 +66,10 @@ public class AddCommand extends Command {
         }
         if (model.hasPersonWithPhone(toAdd.getPhone(), null)) {
             throw new CommandException(MESSAGE_DUPLICATE_PHONE);
+        }
+        if (toAdd.getTeleHandle().isPresent()
+                && model.hasPersonWithTeleHandle(toAdd.getTeleHandle().get(), null)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TELE_HANDLE);
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -58,7 +58,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_DUPLICATE_STUDENT_ID = "This student ID is already used by another student.";
     public static final String MESSAGE_DUPLICATE_EMAIL = "This email is already used by another student.";
     public static final String MESSAGE_DUPLICATE_PHONE = "This phone number is already used by another student.";
-    public static final String MESSAGE_DUPLICATE_TELE_HANDLE = "This Telegram handle is already used by another student.";
+    public static final String MESSAGE_DUPLICATE_TELE_HANDLE =
+            "This Telegram handle is already used by another student.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -58,6 +58,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_DUPLICATE_STUDENT_ID = "This student ID is already used by another student.";
     public static final String MESSAGE_DUPLICATE_EMAIL = "This email is already used by another student.";
     public static final String MESSAGE_DUPLICATE_PHONE = "This phone number is already used by another student.";
+    public static final String MESSAGE_DUPLICATE_TELE_HANDLE = "This Telegram handle is already used by another student.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -103,6 +104,10 @@ public class EditCommand extends Command {
         }
         if (model.hasPersonWithPhone(editedPerson.getPhone(), personToEdit)) {
             throw new CommandException(MESSAGE_DUPLICATE_PHONE);
+        }
+        if (editedPerson.getTeleHandle().isPresent()
+                && model.hasPersonWithTeleHandle(editedPerson.getTeleHandle().get(), personToEdit)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TELE_HANDLE);
         }
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -9,6 +9,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TeleHandle;
 import seedu.address.model.person.UniquePersonList;
 
 /**
@@ -87,6 +88,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         return persons.asUnmodifiableObservableList().stream()
                 .filter(p -> !p.equals(excludePerson))
                 .anyMatch(p -> p.getPhone().equals(phone));
+    }
+
+    /** Checks if any person (excluding {@code excludePerson}) has the given {@code teleHandle}. */
+    public boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson) {
+        requireNonNull(teleHandle);
+        return persons.asUnmodifiableObservableList().stream().filter(p -> !p.equals(excludePerson))
+                .anyMatch(p -> p.getTeleHandle().map(th -> th.equals(teleHandle)).orElse(false));
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TeleHandle;
 
 /**
  * The API of the Model component.
@@ -68,6 +69,9 @@ public interface Model {
      * Returns true if any person in the address book (excluding {@code excludePerson}) has the given {@code phone}.
      */
     boolean hasPersonWithPhone(Phone phone, Person excludePerson);
+
+    /** Returns true if any person (excluding {@code excludePerson}) has the given {@code teleHandle}. */
+    boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson);
 
     /**
      * Deletes the given person.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -110,7 +110,6 @@ public class ModelManager implements Model {
 
     @Override
     public boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson) {
-        requireNonNull(teleHandle);
         return addressBook.hasPersonWithTeleHandle(teleHandle, excludePerson);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TeleHandle;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -105,6 +106,12 @@ public class ModelManager implements Model {
     public boolean hasPersonWithPhone(Phone phone, Person excludePerson) {
         requireNonNull(phone);
         return addressBook.hasPersonWithPhone(phone, excludePerson);
+    }
+
+    @Override
+    public boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson) {
+        requireNonNull(teleHandle);
+        return addressBook.hasPersonWithTeleHandle(teleHandle, excludePerson);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -240,8 +240,7 @@ public class AddCommandTest {
 
         @Override
         public boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson) {
-            return !this.person.equals(excludePerson)
-                    && this.person.getTeleHandle().map(th -> th.equals(teleHandle)).orElse(false);
+            return !this.person.equals(excludePerson) && this.person.getTeleHandle().isPresent();
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TeleHandle;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -185,6 +186,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -231,6 +237,12 @@ public class AddCommandTest {
         public boolean hasPersonWithPhone(Phone phone, Person excludePerson) {
             return !this.person.equals(excludePerson) && this.person.getPhone().equals(phone);
         }
+
+        @Override
+        public boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson) {
+            return !this.person.equals(excludePerson)
+                    && this.person.getTeleHandle().map(th -> th.equals(teleHandle)).orElse(false);
+        }
     }
 
     /**
@@ -257,6 +269,11 @@ public class AddCommandTest {
             return personsAdded.stream()
                     .filter(p -> !p.equals(excludePerson))
                     .anyMatch(p -> p.getPhone().equals(phone));
+        }
+
+        @Override
+        public boolean hasPersonWithTeleHandle(TeleHandle teleHandle, Person excludePerson) {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
## Summary
- Add `hasPersonWithTeleHandle` duplicate check to `AddressBook`, `Model`, and `ModelManager`
- Enforce uniqueness in both `AddCommand` and `EditCommand` — adding or editing a contact with an existing Telegram handle now shows an error
- Update User Guide with the new error message

Fixes #241

## Test plan
- [ ] Add two contacts with the same Telegram handle → should show "This Telegram handle is already used by another person."
- [ ] Edit a contact's Telegram handle to match another existing contact → should show the same error
- [ ] Add/edit contacts with unique handles → should succeed as before
- [ ] Add contacts without a Telegram handle → should still work (handle is optional)