### PR TITLE
Standardize week range parse errors

### DIFF
--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -11,6 +11,7 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Attendance;
 import seedu.address.model.person.TutorialGroup;
 
 /**
@@ -82,14 +83,15 @@ public class MarkCommandParser implements Parser<MarkCommand> {
     }
 
     private static int parseWeek(String weekStr) throws ParseException {
+        int week;
         try {
-            int week = Integer.parseInt(weekStr.trim());
-            if (week <= 0) {
-                throw new NumberFormatException();
-            }
-            return week;
+            week = Integer.parseInt(weekStr.trim());
         } catch (NumberFormatException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE), e);
         }
+        if (week < 1 || week > Attendance.MAX_WEEKS) {
+            throw new ParseException(MarkCommand.MESSAGE_INVALID_WEEK);
+        }
+        return week;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Attendance;
 import seedu.address.model.person.TutorialGroup;
 
 /**
@@ -70,14 +71,15 @@ public class UnmarkCommandParser implements Parser<UnmarkCommand> {
     }
 
     private static int parseWeek(String weekStr) throws ParseException {
+        int week;
         try {
-            int week = Integer.parseInt(weekStr.trim());
-            if (week <= 0) {
-                throw new NumberFormatException();
-            }
-            return week;
+            week = Integer.parseInt(weekStr.trim());
         } catch (NumberFormatException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE), e);
         }
+        if (week < 1 || week > Attendance.MAX_WEEKS) {
+            throw new ParseException(UnmarkCommand.MESSAGE_INVALID_WEEK);
+        }
+        return week;
     }
 }

--- a/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
@@ -120,11 +120,15 @@ public class MarkCommandParserTest {
     public void parse_invalidWeek_throwsParseException() {
         // zero week
         assertParseFailure(parser, "1 " + PREFIX_WEEK + "0",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+                MarkCommand.MESSAGE_INVALID_WEEK);
 
         // negative week
         assertParseFailure(parser, "1 " + PREFIX_WEEK + "-1",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+                MarkCommand.MESSAGE_INVALID_WEEK);
+
+        // above max week
+        assertParseFailure(parser, "1 " + PREFIX_WEEK + "14",
+                MarkCommand.MESSAGE_INVALID_WEEK);
 
         // non-numeric week
         assertParseFailure(parser, "1 " + PREFIX_WEEK + "abc",

--- a/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
@@ -84,9 +84,11 @@ public class UnmarkCommandParserTest {
     @Test
     public void parse_invalidWeek_throwsParseException() {
         assertParseFailure(parser, "1 " + PREFIX_WEEK + "0",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
+                UnmarkCommand.MESSAGE_INVALID_WEEK);
         assertParseFailure(parser, "1 " + PREFIX_WEEK + "-1",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
+                UnmarkCommand.MESSAGE_INVALID_WEEK);
+        assertParseFailure(parser, "1 " + PREFIX_WEEK + "14",
+                UnmarkCommand.MESSAGE_INVALID_WEEK);
         assertParseFailure(parser, "1 " + PREFIX_WEEK + "abc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
     }


### PR DESCRIPTION
Fix #219 

Standardized week parsing so any numeric week outside 1–13 yields Week must be a positive integer between 1 and 13 in both mark/unmark parsers.

Updated parser tests to expect the new week-range error message for out-of-range integers.